### PR TITLE
Possible fix for the Map Image Paths button at LGSL Admin

### DIFF
--- a/modules/lgsl_with_img_mod/lgsl_files/lgsl_class.php
+++ b/modules/lgsl_with_img_mod/lgsl_files/lgsl_class.php
@@ -457,7 +457,7 @@
     $type = preg_replace("/[^a-z0-9_]/", "_", strtolower($type));
     $game = preg_replace("/[^a-z0-9_]/", "_", strtolower($game));
     $map  = preg_replace("/[^a-z0-9_]/", "_", strtolower($map));
-	if ($check_exists !== TRUE) { return "protocol/lgsl/maps/{$type}/{$game}/{$map}.jpg"; }
+	if ($check_exists !== TRUE) { return "modules/lgsl_with_img_mod/lgsl_files/image/cache/{$map}.jpg"; }
 	if ($status) return get_map_path($type,$game,$map);
 	else return "modules/lgsl_with_img_mod/lgsl_files/other/map_no_response.jpg";
   }


### PR DESCRIPTION
When you go to LGSL Admin, and click on the button Map Image Paths, it assumes that the current maps on the online servers are located in path "protocol/lgsl/maps/{$type}/{$game}/{$map}.jpg". It can be true if you upload manually the map image from Game Monitor, but with current module maps go to "modules/lgsl_with_img_mod/lgsl_files/image/cache/{$map}.jpg" The result is that you have 404 errors on all links in this Map Image Paths page if you did not upload manually the map images from Game Monitor.